### PR TITLE
Remove duplicate dependency on sequel

### DIFF
--- a/travis-analyzer.gemspec
+++ b/travis-analyzer.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '= 1.9.3'
 
-  gem.add_dependency "sequel", ['>= 3.35']
   gem.add_dependency "github-linguist", ['>= 4.5']
   gem.add_dependency "rugged", ['>= 0.22']
   gem.add_dependency 'parallel', ['>= 0.7.1']


### PR DESCRIPTION
Or bundler complain:

```
$ bundle install
You have one or more invalid gemspecs that need to be fixed.
The gemspec at /Users/bussonniermatthias/dev/travistorrent-tools/travis-analyzer.gemspec is not valid. Please fix this gemspec.
The validation error was 'duplicate dependency on sequel (>= 4.23), (>= 3.35) use:
    add_runtime_dependency 'sequel', '>= 4.23', '>= 3.35'
```
